### PR TITLE
goMain: only watch go files for now

### DIFF
--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -88,8 +88,11 @@ export function activate(ctx: vscode.ExtensionContext): void {
 		wordPattern: /(-?\d*\.\d\w*)|([^\`\~\!\@\#\%\^\&\*\(\)\-\=\+\[\{\]\}\\\|\;\:\'\"\,\.\<\>\/\?\s]+)/g,
 	});
 
+  // Only watch Go files. The vscode filesystem watcher does
+  // not support more complex matching patterns, otherwise we'd use
+  // a narrower filter that skipped gitignore files.
 	let watcher = vscode.workspace.createFileSystemWatcher(
-		path.join(vscode.workspace.rootPath, '**', '*')
+		path.join(vscode.workspace.rootPath, '**', '*.go')
 	);
 
 	let onChange = _.debounce(runAutorunTest, 200);


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/ignore:

bb4d6fca1b4faae425e5638bf94178c06219f6d2 (2018-05-16 11:31:05 -0400)
goMain: only watch go files for now