### PR TITLE
testUtils: pass along the whole SymbolInfo of a function. remove old testing code

### DIFF
--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -24,7 +24,7 @@ import { GO_MODE } from './goMode';
 import { showHideStatus } from './goStatus';
 import { toggleCoverageCurrentPackage, getCodeCoverage, removeCodeCoverage } from './goCover';
 import { initGoCover } from './goCover';
-import { testAtCursor, testCurrentPackage, testCurrentFile, testPrevious, testWorkspace, setAutorunAtCursor, runAutorunTest, clearAutorunTest } from './goTest';
+import { setAutorunAtCursor, runAutorunTest, clearAutorunTest } from './goTest';
 import { showTestOutput } from './testUtils';
 import * as goGenerateTests from './goGenerateTests';
 import { addImport } from './goImport';

--- a/src/goRunTestCodelens.ts
+++ b/src/goRunTestCodelens.ts
@@ -76,7 +76,8 @@ export class GoRunTestCodeLensProvider extends GoBaseCodeLensProvider {
 
 				let autorun = currentAutorunTestConfig();
 				let autorunTestCmd: Command;
-				if (autorun && autorun.functions && autorun.functions.indexOf(func.name) !== -1) {
+				if (autorun && autorun.functions &&
+					autorun.functions.findIndex((f: vscode.SymbolInformation) => f.name === func.name) !== -1) {
 					autorunTestCmd = {
 						title: 'clear autorun',
 						command: 'go.test.clearAutorunTest'
@@ -85,7 +86,7 @@ export class GoRunTestCodeLensProvider extends GoBaseCodeLensProvider {
 					autorunTestCmd = {
 						title: 'autorun test',
 						command: 'go.test.autoRunTest',
-						arguments: [{functionName: func.name }]
+						arguments: [{ symbol: func }]
 					};
 				}
 

--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -14,7 +14,6 @@ import { getNonVendorPackages } from './goPackages';
 
 let outputChannel = vscode.window.createOutputChannel('Go Tests');
 
-
 /**
  * Input to goTest.
  */
@@ -34,7 +33,7 @@ export interface TestConfig {
 	/**
 	 * Specific function names to test.
 	 */
-	functions?: string[];
+	functions?: vscode.SymbolInformation[];
 	/**
 	 * Test was not requested explicitly. The output should not appear in the UI.
 	 */
@@ -242,7 +241,8 @@ function expandFilePathInOutput(output: string, cwd: string): string {
  */
 function targetArgs(testconfig: TestConfig): Thenable<Array<string>> {
 	if (testconfig.functions) {
-		return Promise.resolve([testconfig.isBenchmark ? '-bench' : '-run', util.format('^%s$', testconfig.functions.join('|'))]);
+		let names = testconfig.functions.map((f) => f.name);
+		return Promise.resolve([testconfig.isBenchmark ? '-bench' : '-run', util.format('^%s$', names.join('|'))]);
 	} else if (testconfig.includeSubDirectories && !testconfig.isBenchmark) {
 		return getGoVersion().then((ver: SemVersion) => {
 			if (ver && (ver.major > 1 || (ver.major === 1 && ver.minor >= 9))) {

--- a/test/go.test.ts
+++ b/test/go.test.ts
@@ -15,7 +15,6 @@ import { getWorkspaceSymbols } from '../src/goSymbol';
 import cp = require('child_process');
 import { getEditsFromUnifiedDiffStr, getEdits } from '../src/diffUtils';
 import jsDiff = require('diff');
-import { testCurrentFile } from '../src/goTest';
 import { getBinPath, getGoVersion, isVendorSupported } from '../src/util';
 import { documentSymbols } from '../src/goOutline';
 import { listPackages, getTextEditForAddImport } from '../src/goImport';
@@ -419,22 +418,6 @@ It returns the number of bytes written and any write error encountered.
 				});
 			}).then(() => done(), done);
 		});
-	});
-
-	test('Test Env Variables are passed to Tests', (done) => {
-		let config = Object.create(vscode.workspace.getConfiguration('go'), {
-			'testEnvVars': { value: { 'dummyEnvVar': 'dummyEnvValue', 'dummyNonString': 1 } }
-		});
-
-		let uri = vscode.Uri.file(path.join(fixturePath, 'sample_test.go'));
-		vscode.workspace.openTextDocument(uri).then(document => {
-			return vscode.window.showTextDocument(document).then(editor => {
-				return testCurrentFile(config, []).then((result: boolean) => {
-					assert.equal(result, true);
-					return Promise.resolve();
-				});
-			});
-		}).then(() => done(), done);
 	});
 
 	test('Test Outline', (done) => {


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/diags:

17bcbb499076695d7505fef4fe3f034aa4b6a4fc (2018-05-16 14:40:25 -0400)
testUtils: pass along the whole SymbolInfo of a function. remove old testing code