### PR TITLE
codelens: show output (ok) or output (FAIL) in the codelens

### DIFF
--- a/src/goBaseCodelens.ts
+++ b/src/goBaseCodelens.ts
@@ -17,8 +17,24 @@ export abstract class GoBaseCodeLensProvider implements vscode.CodeLensProvider 
 		}
 	}
 
+	public rerenderCodeLenses() {
+		this.onDidChangeCodeLensesEmitter.fire();
+	}
+
 	provideCodeLenses(document: vscode.TextDocument, token: vscode.CancellationToken): vscode.ProviderResult<vscode.CodeLens[]> {
 		return [];
 	}
 
+}
+
+let codeLens: GoBaseCodeLensProvider;
+
+export function setDefaultCodeLens(cl: GoBaseCodeLensProvider) {
+	codeLens = cl;
+}
+
+export function rerenderCodeLenses() {
+	if (codeLens) {
+		codeLens.rerenderCodeLenses();
+	}
 }

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -21,12 +21,14 @@ import { isGoPathSet, getBinPath, getExtensionCommands, getGoVersion, getCurrent
 import { clearCacheForTools, fixDriveCasingInWindows } from './goPath';
 import { implCursor } from './goImpl';
 import { initDiagnosticCollection, autotestDisplay } from './diags';
+import { setDefaultCodeLens } from './goBaseCodelens';
 
 export function activate(ctx: vscode.ExtensionContext): void {
 	initDiagnosticCollection(ctx);
 
 	let testCodeLensProvider = new GoRunTestCodeLensProvider();
 	ctx.subscriptions.push(vscode.languages.registerCodeLensProvider(GO_MODE, testCodeLensProvider));
+	setDefaultCodeLens(testCodeLensProvider);
 
 	ctx.subscriptions.push(vscode.workspace.onDidChangeConfiguration(() => {
 		let updatedGoConfig = vscode.workspace.getConfiguration('go', vscode.window.activeTextEditor ? vscode.window.activeTextEditor.document.uri : null);
@@ -67,14 +69,11 @@ export function activate(ctx: vscode.ExtensionContext): void {
 
 	ctx.subscriptions.push(vscode.commands.registerCommand('go.autotest.pin', (args) => {
 		let goConfig = vscode.workspace.getConfiguration('go', vscode.window.activeTextEditor ? vscode.window.activeTextEditor.document.uri : null);
-		setAutorunAtCursor(goConfig, false, args).then(() => {
-		  testCodeLensProvider.rerenderCodeLenses();
-		});
+		setAutorunAtCursor(goConfig, false, args);
 	}));
 
 	ctx.subscriptions.push(vscode.commands.registerCommand('go.autotest.clear', () => {
 		clearAutorunTest();
-		testCodeLensProvider.rerenderCodeLenses();
 	}));
 
 	ctx.subscriptions.push(vscode.commands.registerCommand('go.autotest.show', showAutorunTest));


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/status:

59b45d973eb9efd08e5f224574e5f65a67d541ad (2018-05-18 14:54:46 -0400)
codelens: show output (ok) or output (FAIL) in the codelens