### PR TITLE
autotest a file when saving the file

### DIFF
--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -23,6 +23,11 @@ export interface TestConfig {
 	 */
 	dir: string;
 	/**
+	 * The filename of the file being tested, for bookkeeping so
+	 * that we know when to clear the display.
+	 */
+	fileName: string;
+	/**
 	 * Configuration for the Go extension
 	 */
 	goConfig: vscode.WorkspaceConfiguration;


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/ux2:

36f9a798440aeff7b709bc6cbd6fb8599f26c6f6 (2018-05-21 15:49:15 -0400)
autotest a file when saving the file

30ee18bdeddd5d377b5c662d75d1a22617269302 (2018-05-21 12:22:43 -0400)
when autotesting a file, show the (ok) or (FAIL) in the hover message